### PR TITLE
fix(codeTrafficLight): use padding-top instead of padding

### DIFF
--- a/src/plugins/codeTrafficLight/index.js
+++ b/src/plugins/codeTrafficLight/index.js
@@ -9,6 +9,6 @@ export function codeTrafficLight(theme, devOptions) {
     if (!isPostDetailsPage()) return
 
     insertStyle(
-        `pre[class*='language-'].highlighter-prismjs,pre code.hljs{position:relative;padding:2.5em 1em 1em}pre[class*='language-'].highlighter-prismjs::before,pre code.hljs::before{content:'';position:absolute;top:10px;left:12px;width:12px;height:12px;background:#fe5f59;border-radius:50%;box-shadow:20px 0 #febb2c,40px 0 #29c73f;z-index:2;}`
+        `pre[class*='language-'].highlighter-prismjs,pre code.hljs{position:relative;padding-top:2.5em}pre[class*='language-'].highlighter-prismjs::before,pre code.hljs::before{content:'';position:absolute;top:10px;left:12px;width:12px;height:12px;background:#fe5f59;border-radius:50%;box-shadow:20px 0 #febb2c,40px 0 #29c73f;z-index:2;}`
     )
 }


### PR DESCRIPTION
`pre[class*='language-'].highlighter-prismjs` 加 `padding` 会覆盖prismjs的行号的样式，`padding-top`应该就够了